### PR TITLE
Add Alien startup screen simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# mother
+# Mother
+
+Open `alien.html` in a browser to view the Alien startup screen simulation.

--- a/alien.html
+++ b/alien.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Alien Startup Simulation</title>
+<link href="https://fonts.cdnfonts.com/css/c64-pro-mono" rel="stylesheet">
+<style>
+html, body {
+  height: 100%;
+  margin: 0;
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+#crt {
+  position: relative;
+  width: 800px;
+  height: 600px;
+  background: #001a44;
+  color: #6ec8ff;
+  font-family: 'C64 Pro Mono', monospace;
+  overflow: hidden;
+  padding: 10px;
+  box-shadow: 0 0 10px #001a44, inset 0 0 60px #002a6d;
+  text-shadow: 0 0 4px #6ec8ff;
+  border-radius: 20px;
+  transform: perspective(800px) rotateX(4deg) rotateY(-3deg);
+}
+#crt::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(rgba(255,255,255,0.05) 50%, rgba(0,0,0,0.05) 50%);
+  background-size: 100% 2px;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+#crt::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  background: radial-gradient(circle at center, rgba(255,255,255,0.08) 0%, rgba(0,0,0,0.1) 70%);
+  pointer-events: none;
+  mix-blend-mode: overlay;
+}
+canvas {
+  image-rendering: pixelated;
+  border-radius: 20px;
+  transform: scale(1.02);
+}
+#screen {
+  width: 100%;
+  height: 100%;
+}
+#noise {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0.08;
+  pointer-events: none;
+  mix-blend-mode: overlay;
+}
+#start-msg {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #6ec8ff;
+  background: #001a44;
+  padding: 20px 40px;
+  border: 1px solid #6ec8ff;
+  cursor: pointer;
+  text-shadow: 0 0 4px #6ec8ff;
+}
+</style>
+</head>
+<body>
+<div id="crt">
+  <canvas id="screen" width="800" height="600"></canvas>
+  <canvas id="noise"></canvas>
+  <div id="start-msg">Click to start</div>
+</div>
+<script>
+const canvas = document.getElementById('screen');
+const ctx = canvas.getContext('2d');
+const noiseCanvas = document.getElementById('noise');
+noiseCanvas.width = 100;
+noiseCanvas.height = 75;
+noiseCanvas.style.width = '100%';
+noiseCanvas.style.height = '100%';
+const noiseCtx = noiseCanvas.getContext('2d');
+const rows = 25;
+const cols = 10;
+const colWidth = canvas.width / cols;
+const rowHeight = canvas.height / rows;
+ctx.font = Math.floor(rowHeight * 0.8) + 'px "C64 Pro Mono", monospace';
+ctx.textBaseline = 'top';
+ctx.textAlign = 'left';
+const data = Array.from({length: rows}, () => Array(cols).fill(''));
+let currentCol = 0;
+function randomDecimal() {
+  return (Math.random() * 1000).toFixed(3);
+}
+function draw() {
+  ctx.fillStyle = 'rgba(0,26,68,0.15)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = '#6ec8ff';
+  ctx.shadowColor = '#6ec8ff';
+  ctx.shadowBlur = 4;
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c += 2) {
+      const val = data[r][c];
+      if (val) {
+        ctx.fillText(val, c * colWidth + 2, r * rowHeight + 2);
+      }
+    }
+  }
+  ctx.shadowBlur = 0;
+}
+function renderNoise() {
+  const imageData = noiseCtx.createImageData(noiseCanvas.width, noiseCanvas.height);
+  for (let i = 0; i < imageData.data.length; i += 4) {
+    const v = Math.random() * 255;
+    imageData.data[i] = imageData.data[i + 1] = imageData.data[i + 2] = v;
+    imageData.data[i + 3] = 50;
+  }
+  noiseCtx.putImageData(imageData, 0, 0);
+}
+function tick() {
+  const bottomRow = data[rows - 1];
+  bottomRow[currentCol] = randomDecimal();
+  currentCol += 2;
+  if (currentCol >= cols) {
+    data.push(Array(cols).fill(''));
+    data.shift();
+    currentCol = 0;
+  }
+  draw();
+  renderNoise();
+}
+let interval;
+function start() {
+  document.getElementById('start-msg').style.display = 'none';
+  interval = setInterval(tick, 50);
+}
+const startMsg = document.getElementById('start-msg');
+startMsg.addEventListener('click', start);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create standalone HTML page `alien.html` that simulates Alien's startup screen with CRT bloom, noise, curvature, and printer-like audio
- rename HTML file to avoid merge conflicts and document usage in README
- tone down bloom, remove audio, add Commodore-style font, and tweak curvature

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aec0e3db90832392be9d3b25f38bb9